### PR TITLE
Revamp index with minimalist style

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,70 +1,102 @@
 body {
-	margin: 0;
-	font-family: Helvetica, Geneva, Verdana, sans-serif;
-	background-color: #f8f9fa;
-	color: #000;
+    margin: 0;
+    font-family: Helvetica, Geneva, Verdana, sans-serif;
+    background-color: #f9fafb;
+    color: #333;
 }
 
-/* Navbar Header */
-.navbar-header {
-	background-color: #1e293b; /* dark slate */
-	color: white;
-	padding: 1rem 1rem;
-	display: flex;
-	align-items: center;
-	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-	max-height: 2rem;
+/* Navigation */
+.top-nav {
+    background-color: #fff;
+    color: #333;
+    padding: 0.75rem 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #e5e5e5;
 }
 
 .navbar-title {
-  	font-size: 1.5rem;
-  	font-weight: bold;
+    font-size: 1.5rem;
+    font-weight: bold;
 }
 
-.navbar-links{
-	display: flex;
-	margin-left: 2rem;
+.navbar-links {
+        display: flex;
+        gap: 1rem;
+        align-items: center;
 }
-/*keeps teh links seperate*/
+
 .navbar-links a {
-	display: flex;
-  	color: white;
-  	text-decoration: none;
-  	transition: color 0.2s;
-  	margin: 1rem;
-  	align-items: center;
+        color: inherit;
+        text-decoration: none;
+        transition: color 0.2s;
 }
 
 .navbar-links a:hover {
-  color: #93c5fd; /* light blue on hover */
+    color: #0d9488;
 }
 
 .logs {
-	font-size: 1rem;
-	font-weight: lighter;
-}
-/*to make the links and hovering on links different colors*/
-.navbar-header a {
-	color: #f1f5f9;
-	text-decoration: none;
-	transition: color 0.2s ease;
-}
-
-.navbar-header a:hover {
-	color: #93c5fd; /* light blue */
+        font-size: 1rem;
+        font-weight: lighter;
 }
 
 /* Container */
+
 .container {
-	/*margin: 2rem auto; */
-	padding: 0.5rem;
-	background-color: #0b686a;
-	border-radius: 8px;
-	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
+    padding: 0.5rem;
+    max-width: 700px;
+    margin: 2rem auto;
 }
 
 .signin {
 
-	padding: 0.5rem;
+        padding: 0.5rem;
 
+}
+
+/* Index Page Styles */
+.hero {
+    text-align: center;
+    padding: 3rem 1rem;
+}
+.hero h1 {
+    font-size: 2.25rem;
+    margin-bottom: 0.5rem;
+}
+.hero p {
+    font-size: 1.1rem;
+    max-width: 600px;
+    margin: 0.5rem auto 1rem;
+    line-height: 1.5;
+}
+.tagline {
+    color: #64748b;
+}
+.cta-btn {
+    display: inline-block;
+    background-color: #0d9488;
+    color: #fff;
+    padding: 0.5rem 1.25rem;
+    border-radius: 4px;
+    text-decoration: none;
+    transition: background-color 0.2s;
+}
+.cta-btn:hover {
+    background-color: #0f766e;
+}
+.sample {
+    max-width: 600px;
+    margin: 2rem auto;
+    text-align: center;
+}
+.sample-exercise {
+    margin-top: 1rem;
+    font-size: 1.1rem;
+}
+.check-btn {
+    margin-top: 1rem;
+    padding: 0.4rem 1rem;
+    font-size: 1rem;
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,48 +17,24 @@
 	{% endblock %}
 
 	{% block navbar %}
-	<nav>
-		<div class="navbar navbar-inverse" role="navigation">
-			<div class="container">
-				<div class="navbar-header">
-<!--					<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-						<span class="sr-only">Toggle navigation</span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-					</button> -->
-
-					<div class="navbar-title">
-						THINKFUL
-					</div>
-
-					<div class="navbar-links">
-						<a href="/">Home</a>
-
-						<div class="logs">
-							{% if not current_user.is_authenticated %}
-								<a href="/login">Login</a>
-							{%else %}
-								<a href="/logout">Logout</a>
-							{% endif %}
-						</div>
-
-						<a href="{{url_for('text')}}">Daily</a>
-						
-						<div class="register or practice">
-							{% if not current_user.is_authenticated %}
-								<a href="/register">Register</a>
-							{%else %}
-								<a href="/profile">Profile</a>
-							{% endif %}
-						</div>
-					</div>
-					
-				</div>
-			</div>
-		</div>
-	</nav>
-	{% endblock %}
+<nav class="top-nav">
+    <div class="navbar-title">THINKFUL</div>
+    <div class="navbar-links">
+        <a href="/">Home</a>
+        {% if not current_user.is_authenticated %}
+            <a href="/login">Login</a>
+        {% else %}
+            <a href="/logout">Logout</a>
+        {% endif %}
+        <a href="{{ url_for('text') }}">Daily</a>
+        {% if not current_user.is_authenticated %}
+            <a href="/register">Register</a>
+        {% else %}
+            <a href="/profile">Profile</a>
+        {% endif %}
+    </div>
+</nav>
+{% endblock %}
 
 	{% block content %}
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -13,82 +13,16 @@ const correctAnswers = ["mitochondria"]
 {% endblock %}
 
 {% block content %}
-
-<head>
-<style>
-/*h1 {
-	text-align: center;
-}
-
-h4 {
-	text-align: center;
-}
-
-h5 {
-	text-align: left;
-}*/
-/*sets the size for each of the elements below*/
-div.head {
-	width: 1 rem;
-	margin: auto;
-	font-weight: bold;
-	font-size: xx-large;
-	text-align: center;
-	font-family: Arial, Helvetica, sans-serif;
-}
-div.bod{
-	width: 1 rem;
-	margin: auto;
-	/*font-weight: bold;*/
-	font-size: x-large;
-	text-align: center;
-	font-family: Arial, Helvetica, sans-serif;
-
-}
-div.ex{
-	width: 1 rem;
-	margin: auto;
-	font-weight: bold;
-	font-size: x-large;
-	/*text-align: center;*/
-	font-family: Arial, Helvetica, sans-serif;
-
-}
-div.smallex{
-	width: 1 rem;
-	margin: auto;
-	/*font-weight: bold;*/
-	font-size: x-large;
-	/*text-align: center;*/
-	font-family: Arial, Helvetica, sans-serif;
-	padding-left: 50px
-}
-div.smallex button {
-	display: block;
-	margin: 50px; 
-	/*margin: auto;*/
-	/*font-weight: bold;*/
-	font-size: x-large;
-	/*text-align: center;*/
-	font-family: Arial, Helvetica, sans-serif;
-	margin-left: 0;
-}
-</style>
-
-</head>
-
-<div id="jiejfiejf">
-	<br><br>
-	<div class = "head"> The fill in the blank-style review website that will teach you everything you need to know about the biggest science subjects! </div>
-	<br><br><br><br>
-	<div class = "bod"> Thinkful provides the user with a daily fill in the blank exercise sourced directly from LibreTexts textbooks. <br><br>
-	Every day cycles between a mini-lesson in astronomy, biology, chemistry, and physics. You will be provided with a paragraph with several blanks to insert key terms in. You can select your answers via a dropdown menu for each blank, and you can check your answers to see how many you got correct. <br><br>After checking, every right and wrong answer blank will feature a pop-up explaining why you were right or wrong. A link to the textbook lesson from which your exercise for the day was generated will appear below the exercise if you want to read about and better understand that day's lesson. <br><br>
-	The more days you learn with Thinkful, the more advanced topics you will discover.<br><br><br><br> </div>
-	<div class="ex"> Here is a sample exercise: <br></div>
-
+<div class="hero">
+    <h1>Thinkful</h1>
+    <p class="tagline">Every day a new textbook sentence is released. Fill in the blanks and see what you remember.</p>
+    <a class="cta-btn" href="{{ url_for('text') }}">Try Today's Exercise</a>
 </div>
 
-<div id="output" class="smallex"></div>
-	<button style="margin-left:100px; font-size:20px;" onclick="checkAnswers()">Check Answers</button>
+<div class="sample">
+    <h2>Sample Exercise</h2>
+    <div id="output" class="sample-exercise"></div>
+    <button class="check-btn" onclick="checkAnswers()">Check Answers</button>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- simplify landing page text and CTA
- streamline navigation and page colors for a minimal look

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68503afc25748333ac24e6f459886ef2